### PR TITLE
Add orchestrator with credential validation and resilience

### DIFF
--- a/credentials_validator.py
+++ b/credentials_validator.py
@@ -1,0 +1,127 @@
+"""Utility helpers to validate environment credentials for Vendedor360.
+
+This module centralises the logic required to verify that all mandatory
+credentials are available before the orchestrator attempts to execute an
+agent. Each agent may require one or more environment variables and in some
+cases at least one variable from a group (e.g. ``MP_TICKET`` *or*
+``MP_SESSION_COOKIE``).
+
+The :class:`CredentialValidator` class performs the validation and returns a
+structured report that can be consumed by the orchestrator to decide whether a
+step should run or be skipped. The data classes are intentionally lightweight so
+that they can also be reused in tests if needed.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+import os
+
+
+@dataclass(frozen=True)
+class CredentialRequirement:
+    """Describe a set of environment variables required for a feature."""
+
+    name: str
+    env_vars: Sequence[str]
+    mode: str = "all"
+    optional: bool = False
+    hint: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.mode not in {"all", "any"}:
+            raise ValueError("mode must be 'all' or 'any'")
+        if not self.env_vars:
+            raise ValueError("env_vars must contain at least one item")
+
+
+@dataclass
+class CredentialStatus:
+    """Represents the evaluation of a single requirement."""
+
+    requirement: CredentialRequirement
+    present: Sequence[str]
+    missing: Sequence[str]
+    satisfied: bool
+
+    @property
+    def optional(self) -> bool:
+        return self.requirement.optional
+
+
+@dataclass
+class ValidationReport:
+    """Aggregate result of credential validation."""
+
+    statuses: Sequence[CredentialStatus]
+
+    @property
+    def ok(self) -> bool:
+        """Return ``True`` if every mandatory requirement is satisfied."""
+
+        for status in self.statuses:
+            if not status.satisfied and not status.optional:
+                return False
+        return True
+
+    @property
+    def missing_variables(self) -> list[str]:
+        """Flatten the missing mandatory environment variables."""
+
+        missing: list[str] = []
+        for status in self.statuses:
+            if not status.satisfied and not status.optional:
+                missing.extend(status.missing)
+        return missing
+
+    def summary(self) -> str:
+        """Return a human readable summary of missing credentials."""
+
+        messages: list[str] = []
+        for status in self.statuses:
+            if status.satisfied or status.optional:
+                continue
+            requirement = status.requirement
+            hint = f" ({requirement.hint})" if requirement.hint else ""
+            if requirement.mode == "any":
+                targets = " o ".join(requirement.env_vars)
+                messages.append(f"{requirement.name}: define {targets}{hint}")
+            else:
+                targets = ", ".join(requirement.env_vars)
+                messages.append(f"{requirement.name}: falta {targets}{hint}")
+        return "; ".join(messages)
+
+
+class CredentialValidator:
+    """Validate credentials stored in environment variables."""
+
+    def __init__(self, environ: Mapping[str, str] | None = None) -> None:
+        self._environ = environ if environ is not None else os.environ
+
+    def _check(self, requirement: CredentialRequirement) -> CredentialStatus:
+        present = [var for var in requirement.env_vars if self._environ.get(var)]
+        missing = [var for var in requirement.env_vars if not self._environ.get(var)]
+        if requirement.mode == "all":
+            satisfied = not missing
+        else:  # mode == "any"
+            satisfied = bool(present)
+        if requirement.optional and not satisfied:
+            # Optional credentials are informative but do not fail the report.
+            satisfied = True
+        return CredentialStatus(
+            requirement=requirement,
+            present=present,
+            missing=missing,
+            satisfied=satisfied,
+        )
+
+    def validate(self, requirements: Iterable[CredentialRequirement]) -> ValidationReport:
+        """Validate a sequence of credential requirements."""
+
+        statuses = [self._check(req) for req in requirements]
+        return ValidationReport(statuses=statuses)
+
+    def check(self, *requirements: CredentialRequirement) -> ValidationReport:
+        """Convenience wrapper calling :meth:`validate`."""
+
+        return self.validate(requirements)

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,210 @@
+"""Main orchestration entry-point for Vendedor360."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+import argparse
+import logging
+import subprocess
+import sys
+import time
+
+from agents.common.status import append_status
+from credentials_validator import CredentialRequirement, CredentialValidator
+from resilience import RetryPolicy, execute_with_retry, ResilienceError
+
+
+log = logging.getLogger("orchestrator")
+
+
+@dataclass
+class Task:
+    """Representation of a runnable task within the orchestrator."""
+
+    name: str
+    command: list[str]
+    credentials: Iterable[CredentialRequirement]
+    retries: int = 2
+
+
+def load_config(path: Path) -> dict:
+    """Load the ``agent_config.yaml`` file without external dependencies."""
+
+    config: dict[str, dict] = {}
+    if not path.exists():
+        return config
+    current_section: str | None = None
+    with path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.split("#", 1)[0].rstrip()
+            if not line:
+                continue
+            if not line.startswith(" ") and line.endswith(":"):
+                current_section = line[:-1].strip()
+                config.setdefault(current_section, {})
+                continue
+            if ":" in line:
+                key, value = line.split(":", 1)
+                key = key.strip()
+                value = value.strip().strip('"')
+                if current_section:
+                    config.setdefault(current_section, {})[key] = _parse_scalar(value)
+                else:
+                    config[key] = _parse_scalar(value)
+    return config
+
+
+def _parse_scalar(value: str) -> object:
+    if value.lower() in {"true", "false"}:
+        return value.lower() == "true"
+    try:
+        if "." in value:
+            return float(value)
+        return int(value)
+    except ValueError:
+        return value
+
+
+def build_tasks(config: dict, status_path: Path) -> list[Task]:
+    """Construct the tasks executed per cycle."""
+
+    cola = str(config.get("paths", {}).get("postulaciones_csv", "queues/postulaciones.csv"))
+    since = str(int(config.get("params", {}).get("ventana_horas", 24)))
+    python = sys.executable
+    tasks: list[Task] = [
+        Task(
+            name="Mercado Público",
+            command=[
+                python,
+                "agents/mp/run.py",
+                "--cola",
+                cola,
+                "--status",
+                str(status_path),
+                "--since-hours",
+                since,
+            ],
+            credentials=[
+                CredentialRequirement(
+                    name="Mercado Público",
+                    env_vars=["MP_TICKET", "MP_SESSION_COOKIE"],
+                    mode="any",
+                    hint="Exporta MP_TICKET o MP_SESSION_COOKIE",
+                )
+            ],
+            retries=3,
+        ),
+        Task(
+            name="Meta/Marketplace",
+            command=[python, "agents/meta/run.py", "--status"],
+            credentials=[
+                CredentialRequirement("Meta Access Token", ["META_ACCESS_TOKEN"], hint="Necesario para la Graph API"),
+                CredentialRequirement("Meta App ID", ["META_APP_ID"]),
+            ],
+            retries=2,
+        ),
+        Task(
+            name="LinkedIn",
+            command=[python, "agents/linkedin/run.py", "--status", str(status_path)],
+            credentials=[
+                CredentialRequirement("LinkedIn Token", ["LINKEDIN_ACCESS_TOKEN"], hint="Genera un token en LinkedIn"),
+            ],
+            retries=2,
+        ),
+    ]
+    return tasks
+
+
+def run_command(task: Task, log_dir: Path) -> tuple[str, Path]:
+    """Execute a task command with retries and return the resulting state."""
+
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    slug = task.name.lower().replace("/", "-").replace(" ", "_")
+    log_file = log_dir / f"{slug}_{timestamp}.log"
+
+    def _invoke() -> subprocess.CompletedProcess[str]:
+        log.info("Running task %s", task.name)
+        return subprocess.run(
+            task.command,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+    try:
+        completed = execute_with_retry(
+            _invoke,
+            policy=RetryPolicy(max_attempts=task.retries),
+            exceptions=(subprocess.CalledProcessError,),
+            logger=log,
+        )
+        stdout, stderr = completed.stdout, completed.stderr
+        state = "ok"
+        motivo = "ejecutado"
+    except ResilienceError as exc:
+        # Last attempt raised a CalledProcessError. Preserve the details.
+        stdout = getattr(exc.__cause__, "stdout", "")
+        stderr = getattr(exc.__cause__, "stderr", str(exc))
+        state = "error"
+        motivo = str(exc.__cause__ or exc)
+    except Exception as exc:  # pylint: disable=broad-except
+        stdout, stderr = "", str(exc)
+        state = "error"
+        motivo = str(exc)
+
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file.write_text(
+        f"Comando: {' '.join(task.command)}\nEstado: {state}\nMotivo: {motivo}\n\nSTDOUT:\n{stdout}\n\nSTDERR:\n{stderr}\n",
+        encoding="utf-8",
+    )
+    return state, log_file
+
+
+def run_cycle(tasks: Iterable[Task], validator: CredentialValidator, status_path: Path, log_dir: Path) -> None:
+    resumen: list[dict[str, str]] = []
+    for task in tasks:
+        report = validator.validate(task.credentials)
+        if not report.ok:
+            motivo = report.summary() or "faltan_credenciales"
+            append_status(status_path, task.name, [{"estado": "skip", "motivo": motivo}])
+            resumen.append({"tarea": task.name, "estado": "skip", "motivo": motivo})
+            continue
+        estado, log_file = run_command(task, log_dir)
+        append_status(status_path, task.name, [{"estado": estado, "motivo": str(log_file)}])
+        resumen.append({"tarea": task.name, "estado": estado, "log": str(log_file)})
+    append_status(status_path, "Orquestador", resumen)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Orquestador principal de Vendedor360")
+    parser.add_argument("--config", default="agent_config.yaml")
+    parser.add_argument("--mode", choices=["run_once", "watch"], help="Sobrescribe el modo configurado")
+    parser.add_argument("--interval", type=int, help="Intervalo en minutos para modo watch")
+    parser.add_argument("--log-level", default="INFO")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    config = load_config(Path(args.config))
+    params = config.get("params", {})
+    mode = args.mode or params.get("modo", "run_once")
+    interval = args.interval or int(params.get("watch_interval_min", 10))
+    status_path = Path(config.get("paths", {}).get("status_md", "STATUS.md"))
+    log_dir = Path(config.get("paths", {}).get("logs_dir", "logs"))
+
+    validator = CredentialValidator()
+    tasks = build_tasks(config, status_path)
+
+    while True:
+        run_cycle(tasks, validator, status_path, log_dir)
+        if mode != "watch":
+            break
+        log.info("Esperando %s minutos antes del siguiente ciclo", interval)
+        time.sleep(max(1, interval) * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/resilience.py
+++ b/resilience.py
@@ -1,0 +1,83 @@
+"""Resilience helpers for the Vendedor360 automation suite."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Iterable, TypeVar
+import logging
+import random
+import time
+
+
+_T = TypeVar("_T")
+
+
+@dataclass
+class RetryPolicy:
+    """Configuration for retry/backoff logic."""
+
+    max_attempts: int = 3
+    initial_delay: float = 1.0
+    backoff_factor: float = 2.0
+    max_delay: float = 60.0
+    jitter: float = 0.15
+
+    def get_delay(self, attempt: int) -> float:
+        """Return the delay (in seconds) for a given attempt."""
+
+        delay = self.initial_delay * (self.backoff_factor ** max(0, attempt - 1))
+        delay = min(delay, self.max_delay)
+        if self.jitter:
+            jitter_range = (1 - self.jitter, 1 + self.jitter)
+            delay *= random.uniform(*jitter_range)
+        return delay
+
+
+class ResilienceError(RuntimeError):
+    """Custom error raised when retries are exhausted."""
+
+
+def execute_with_retry(
+    func: Callable[[], _T],
+    *,
+    policy: RetryPolicy | None = None,
+    exceptions: Iterable[type[BaseException]] | None = None,
+    logger: logging.Logger | None = None,
+) -> _T:
+    """Execute ``func`` retrying transient failures."""
+
+    policy = policy or RetryPolicy()
+    allowed = tuple(exceptions or (Exception,))
+    attempt = 1
+    while True:
+        try:
+            return func()
+        except allowed as exc:  # type: ignore[arg-type]
+            if attempt >= policy.max_attempts:
+                raise ResilienceError("max retries exceeded") from exc
+            delay = policy.get_delay(attempt)
+            if logger:
+                logger.warning(
+                    "Retry %s/%s after error: %s. Waiting %.2fs",
+                    attempt,
+                    policy.max_attempts,
+                    exc,
+                    delay,
+                )
+            time.sleep(delay)
+            attempt += 1
+
+
+def retryable(policy: RetryPolicy | None = None, **kwargs):
+    """Decorator applying :func:`execute_with_retry` to the wrapped callable."""
+
+    def decorator(func: Callable[..., _T]):
+        def wrapper(*args, **inner_kwargs):
+            return execute_with_retry(
+                lambda: func(*args, **inner_kwargs),
+                policy=policy,
+                **kwargs,
+            )
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary
- add a reusable credentials validator to centralise environment checks
- introduce retry utilities to improve resilience across automation steps
- implement a configurable orchestrator that validates credentials, runs each agent with retries, and records execution status

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_690c06466e10832f9854da68e79f3031